### PR TITLE
Allow grass connection from the ningis servers

### DIFF
--- a/R/grassConnect.R
+++ b/R/grassConnect.R
@@ -20,7 +20,7 @@
 grassConnect <- function(location="ETRS_33N", mapset="user"){
     host <- NULL
     try(host <- system("hostname", intern = T))
-    if (grepl("ninrstudio", host)) {
+    if (grepl("ninrstudio|ningis", host)) {
       require(rgrass7)
       gisDbase <- "/data/grass"
       #location <- "ETRS_33N"


### PR DESCRIPTION
I changed the expression in line 23 to `grepl("ninrstudio|ningis", host)` to allow one to connect to the GRASS GIS db from the GIS servers as well