### PR TITLE
Adding new path for rstudio to access GRASS

### DIFF
--- a/R/grassConnect.R
+++ b/R/grassConnect.R
@@ -19,7 +19,7 @@
 grassConnect <- function(location="ETRS_33N", mapset="user"){
   host <- NULL
   try(host <- system("hostname", intern = T))
-  if (grepl("ninrstudio|ningis|lipgis", host)) {
+  if (grepl("ninrstudio|ningis|lipgis|liprstudio", host)) {
 
     gisDbase <- "/data/grass"
     #location <- "ETRS_33N"


### PR DESCRIPTION
I had previously made an addition to allow access from ningis server. Now I am adding new path for rstudio to allow access to GRASS from rstudio server - Needed since the last update in the RStudio server at NINA.